### PR TITLE
Chicago's joining the elevator party

### DIFF
--- a/chicago_api.rb
+++ b/chicago_api.rb
@@ -1,0 +1,47 @@
+require 'faraday'
+require 'nokogiri'
+
+require 'models'
+
+class ChicagoApiError < StandardError; end
+
+class ChicagoApi # Chicago
+  CHICAGO_ENDPOINT = 'http://www.transitchicago.com/travel_information/accessibility_status.aspx'.freeze
+
+  def self.get_data
+    begin
+      response = Faraday.get(CHICAGO_ENDPOINT).body
+    rescue StandardError => e
+      raise ChicagoApiError, "ERROR: #{e.class}: #{e.message}"
+    end
+
+    html = Nokogiri::HTML.parse(response) do |config|
+      config.strict.noblanks
+    end
+
+    messages = html.xpath('//a[@class="bold padrt"]').to_a.map(&:text)
+    # ["Roosevelt Street-to-Mezzanine Elevator Out of Service", "Western Kimball-bound Platform Elevator Out of Service", "Elevator at 18th Temporarily Out-of-Service"]
+    long_desc = html.xpath('//div[@class="col500"]/text()[preceding::div[@class="planned"] and following::div[@class="alertdate"]]').to_a.map{|e| e.text.strip}.reject(&:empty?)
+    # ["Red Line - The street-to-mezzanine elevator at the Roosevelt subway station will be temporarily out of service.", "Brown Line - The Kimball-bound platform elevator at the Western station will be temporarily out of service.", "The elevator to the 54th/Cermak-bound platform at 18th (Pink Line) is temporarily out-of-service."]
+
+    elevator_names = []
+    cta_lines = %w(Red Blue Brown Green Orange Purple Pink Yellow)
+
+    messages.zip(long_desc).each do |msg, desc|
+      e = msg.sub(/(?:Temporarily )?Out.of.Service/i, '')
+             .sub(/Elevator at/i, '')
+             .sub(/Street.to.Mezzanine/i, '')
+             .sub(/Elevator/i, '')
+             .strip
+      cta_line = (desc.downcase.split(/\W+/) & cta_lines.map(&:downcase))[0]
+      cta_line = " #{cta_line.capitalize}" if cta_line
+      if e && e != ''
+        elevator_names << "Chicago#{cta_line}: #{e}".gsub(/\s+/, ' ')
+      else
+        Models::Unparseable.first_or_create(:data => msg)
+      end
+    end
+
+    elevator_names
+  end
+end

--- a/worker.rb
+++ b/worker.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'models'
 require 'bart_api'
 require 'muni_api'
+require 'chicago_api'
 require 'notifier'
 require 'my_rollbar'
 
@@ -38,10 +39,16 @@ class Worker
       Models::Elevator.first_or_create(:name => name)
     end
 
+    # Chicago
+    chicago_data = ChicagoApi.get_data
+    out_elevators += chicago_data.map do |name|
+      Models::Elevator.first_or_create(:name => name)
+    end
+
     total_count = Models::Elevator.count
 
     puts "New elevators: #{total_count - existing_count}."
-    puts "Data: #{bart_data}, #{muni_data}"
+    puts "Data: #{bart_data}, #{muni_data}", "#{chicago_data}"
 
     outages_to_notify = []
 


### PR DESCRIPTION
I didn't test it. Sorry. Returns:

```
2.1.4 :001 > ChicagoApi.get_data
 => ["Chicago Red: Roosevelt", "Chicago Brown: Western Kimball-bound Platform", "Chicago Pink: 18th"] 
```

The cta line chosen comes from the long description, while the elevator/stop comes from the message (short description) which is parsed heavily. Below is the raw data example from 23/01/2017 @ 7:40PM CST.

```
[1] pry(ChicagoApi)> messages
=> ["Roosevelt Street-to-Mezzanine Elevator Out of Service", "Western Kimball-bound Platform Elevator Out of Service", "Elevator at 18th Temporarily Out-of-Service"]

[2] pry(ChicagoApi)> long_desc
=> ["Red Line - The street-to-mezzanine elevator at the Roosevelt subway station will be temporarily out of service.",
 "Brown Line - The Kimball-bound platform elevator at the Western station will be temporarily out of service.",
 "The elevator to the 54th/Cermak-bound platform at 18th (Pink Line) is temporarily out-of-service."]
```