### PR TITLE
Add an alias-elevator hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ elevator_alerts.sql
 
 And remove any user not found in reports - (1,9,10,12,14,19,24,26), as well as
 those users' SMS numbers.
+
+Handling Dupe Elevator Names
+============================
+The `elevators` table contains an `alias_id` column.  If this id is set, then
+when that elevator is marked in or out by the API, we'll convert it to the
+original elevator (whose id is `alias_id`).
+
+Maintenance of `alias_id` values is by-hand.

--- a/models.rb
+++ b/models.rb
@@ -45,6 +45,7 @@ module Models
 
     property :id, Serial, :key => true
     property :name, String, :index => true, :unique => true
+    property :alias_id, Integer, :required => false
 
     #has n, :systems, :through => :stations
     has n, :outages, :through => Resource


### PR DESCRIPTION
Elevators now have an 'alias_id' column; if this column is empty, it's
just an elevator, no special handling.  If it's set, that means the name
of the elevator is just an alias for the elevator whose id is alias_id.

Maintaining these alias_ids, and reconciling outages that have been
opened for aliased elevators, is currently a manual process.